### PR TITLE
fix: use symfony sanctioned simple filter declaration

### DIFF
--- a/lib/Teraone/Twig/Extension/StrftimeExtension.php
+++ b/lib/Teraone/Twig/Extension/StrftimeExtension.php
@@ -25,7 +25,7 @@ class StrftimeExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'strftime' => new Twig_SimpleFilter('strftime', $this,
+            new Twig_SimpleFilter('strftime', [$this, 'strftime'],
                 array('needs_environment' => true)),
         );
     }


### PR DESCRIPTION
We stumbled upon this error after a `$ composer install` : 

```
[2017-09-19 17:08:11] app.CRITICAL: Twig_Error_Syntax : An exception has been thrown during the compilation of a template ("Method __invoke does not exist") in "themes/default/marketplace/sms/header.sms.twig". ...
```

By examining the compiled `Twig_Environment` and examining the **stack trace** of said `Exception`, I realized there could be something wrong with the way the `strftime` filter is declared.

I used the syntax defined here : https://symfony.com/doc/current/templating/twig_extension.html