### PR TITLE
accept  date argument as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Use strftime in twig
 
 {{ date()|strftime('%I:%M:%S %p') }} //-> Display the current time
 
+{{ '2017-12-01'|strftime('%d %B %Y') }} //-> Accept string filtering (compatible with strtotime)
+
 ```
 
 # Installation

--- a/lib/Teraone/Twig/Extension/StrftimeExtension.php
+++ b/lib/Teraone/Twig/Extension/StrftimeExtension.php
@@ -32,12 +32,12 @@ class StrftimeExtension extends \Twig_Extension
 
     /**
      * @param Twig_Environment $env
-     * @param DateTime $date
+     * @param DateTime|string $date
      * @param string $format
      * @param mixed $timezone
      * @return string
      */
-    public function strftime(Twig_Environment $env, DateTime $date,
+    public function strftime(Twig_Environment $env, $date,
                              $format = "%B %e, %Y %H:%M", $timezone = null)
     {
         $date = twig_date_converter($env, $date, $timezone);


### PR DESCRIPTION
You should accept the data argument as a string thanks to twig_date_converter which accepts string and Datetime format.

The filter would be far more versatile and could filter something like {{ '2017-12-11'|strftime('%d %B %Y') }}